### PR TITLE
Cleanup and improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/.project

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # qiot-image-build
 
 This project provides the needed scripts and files for building the custom fedora-iot image used at the edge in Quarkus IoT Project.
+
+The build provess is based on the Anaconda/Kickstart projects.
+
+Please refer to the pofficial base kickstart from the fedora community [here](https://pagure.io/fedora-kickstarts/raw/f33/f/fedora-iot.ks).
+
+The overall build process takes roughly 2 hours, so be patient ;-)

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 virt-install --connect=qemu:///system \
-    --network=bridge:virbr0 \
+    --network=default \
     --initrd-inject=./fedora-qiot.ks \
     --extra-args="ks=file:/fedora-qiot.ks" \
     --name=fedora-33-qiot.aarch64 \


### PR DESCRIPTION
Did some cleanup removing comments and restructuring commands in the kickstart file
Extended the kickstart file with additional commands
Missing functionalities due to the Anaconda/Kickstart installation:

- [ ] install _i2c-tools_ library via the command `rpm-ostree install i2c-tools`
- [ ] change U-Boot env variable _bootdelay=-2_ via the command `fw_setenv bootdelay -- -2`

both the above work on a running instance of the resulting build